### PR TITLE
count avatar joint updates and non-updates

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -107,11 +107,11 @@ Item {
                     }
                     StatText {
                         visible: root.expanded
-                        text: "Fully Simulated Avatars: " + root.fullySimulatedAvatarCount
+                        text: "Avatars Updated: " + root.updatedAvatarCount
                     }
                     StatText {
                         visible: root.expanded
-                        text: "Partially Simulated Avatars: " + root.partiallySimulatedAvatarCount
+                        text: "Avatars NOT Updated: " + root.notUpdatedAvatarCount
                     }
                 }
             }

--- a/interface/src/avatar/Avatar.h
+++ b/interface/src/avatar/Avatar.h
@@ -183,6 +183,8 @@ public:
 
     Q_INVOKABLE float getSimulationRate(const QString& rateName = QString("")) const;
 
+    bool hasNewJointData() const { return _hasNewJointData; }
+
 public slots:
 
     // FIXME - these should be migrated to use Pose data instead

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -43,8 +43,8 @@ public:
     std::shared_ptr<MyAvatar> getMyAvatar() { return _myAvatar; }
     AvatarSharedPointer getAvatarBySessionID(const QUuid& sessionID) const override;
 
-    int getFullySimulatedAvatars() const { return _fullySimulatedAvatars; }
-    int getPartiallySimulatedAvatars() const { return _partiallySimulatedAvatars; }
+    int getNumAvatarsUpdated() const { return _numAvatarsUpdated; }
+    int getNumAvatarsNotUpdated() const { return _numAvatarsNotUpdated; }
     float getAvatarSimulationTime() const { return _avatarSimulationTime; }
 
     void updateMyAvatar(float deltaTime);
@@ -120,8 +120,8 @@ private:
     VectorOfMotionStates _motionStatesToRemoveFromPhysics;
 
     RateCounter<> _myAvatarSendRate;
-    int _fullySimulatedAvatars { 0 };
-    int _partiallySimulatedAvatars { 0 };
+    int _numAvatarsUpdated { 0 };
+    int _numAvatarsNotUpdated { 0 };
     float _avatarSimulationTime { 0.0f };
 };
 

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -121,8 +121,8 @@ void Stats::updateStats(bool force) {
     auto avatarManager = DependencyManager::get<AvatarManager>();
     // we need to take one avatar out so we don't include ourselves
     STAT_UPDATE(avatarCount, avatarManager->size() - 1);
-    STAT_UPDATE(fullySimulatedAvatarCount, avatarManager->getFullySimulatedAvatars());
-    STAT_UPDATE(partiallySimulatedAvatarCount, avatarManager->getPartiallySimulatedAvatars());
+    STAT_UPDATE(updatedAvatarCount, avatarManager->getNumAvatarsUpdated());
+    STAT_UPDATE(notUpdatedAvatarCount, avatarManager->getNumAvatarsNotUpdated());
     STAT_UPDATE(serverCount, (int)nodeList->size());
     STAT_UPDATE(framerate, qApp->getFps());
     if (qApp->getActiveDisplayPlugin()) {

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -49,8 +49,8 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, simrate, 0)
     STATS_PROPERTY(int, avatarSimrate, 0)
     STATS_PROPERTY(int, avatarCount, 0)
-    STATS_PROPERTY(int, fullySimulatedAvatarCount, 0)
-    STATS_PROPERTY(int, partiallySimulatedAvatarCount, 0)
+    STATS_PROPERTY(int, updatedAvatarCount, 0)
+    STATS_PROPERTY(int, notUpdatedAvatarCount, 0)
     STATS_PROPERTY(int, packetInCount, 0)
     STATS_PROPERTY(int, packetOutCount, 0)
     STATS_PROPERTY(float, mbpsIn, 0)
@@ -159,8 +159,8 @@ signals:
     void simrateChanged();
     void avatarSimrateChanged();
     void avatarCountChanged();
-    void fullySimulatedAvatarCountChanged();
-    void partiallySimulatedAvatarCountChanged();
+    void updatedAvatarCountChanged();
+    void notUpdatedAvatarCountChanged();
     void packetInCountChanged();
     void packetOutCountChanged();
     void mbpsInChanged();


### PR DESCRIPTION
This PR counts the number of avatars in view with fresh `_jointData` that were:

(1) successfully updated
(2) unable to be updated